### PR TITLE
List aliases with `--alias list`

### DIFF
--- a/isos_post.py
+++ b/isos_post.py
@@ -72,6 +72,12 @@ if args.alias:
                             'wicked_basic': 'wicked_basic_ref,wicked_basic_sut',
                             'wicked_startandstop': 'wicked_startandstop_ref,wicked_startandstop_sut',
                             'wicked_aggregate': 'wicked_aggregate_ref,wicked_aggregate_sut'}
+    if (args.alias == 'list'):
+        print('Aliases:')
+        for key, value in available_testsuites.items():
+            print("  {:20s} => {}".format(key, value))
+        sys.exit(0);
+
     testsuites = []
     testsuites = args.alias.split(',')
     result_string = ''


### PR DESCRIPTION
List alias like:

```
 isos_post.py --alias list
Aliases:
  mrsh                 => hpc_mrsh_master,hpc_mrsh_slave,hpc_mrsh_supportserver
  munge                => hpc_munge_master,hpc_munge_slave,hpc_munge_supportserver
  pdsh                 => hpc_pdsh_master,hpc_pdsh_slave,hpc_pdsh_supportserver
  slurm                => hpc_slurm_master,hpc_slurm_slave,hpc_slurm_supportserver
  ganglia              => hpc_ganglia_server,hpc_ganglia_client,hpc_ganglia_supportserver
  pdsh_genders         => hpc_pdsh_genders_master,hpc_pdsh_genders_slave,hpc_pdsh_genders_supportserver
  network              => wicked_advanced_ref,wicked_advanced_sut,wicked_basic_sut,wicked_basic_ref,wicked_startandstop_ref,wicked_startandstop_sut
  wicked_advanced      => wicked_advanced_ref,wicked_advanced_sut
  wicked_2nics         => wicked_2nics_ref,wicked_2nics_sut
  wicked_basic         => wicked_basic_ref,wicked_basic_sut
  wicked_startandstop  => wicked_startandstop_ref,wicked_startandstop_sut
  wicked_aggregate     => wicked_aggregate_ref,wicked_aggregate_sut
```